### PR TITLE
style: fix deno fmt formatting in media/logo.svg

### DIFF
--- a/media/logo.svg
+++ b/media/logo.svg
@@ -24,8 +24,7 @@
     <path
       d="M227.203125,55.0042941 C220.403055,55.0042941 212.562245,64.2846185 204.964643,77.1351713 C200.362027,60.3167979 194.145762,47 186,47 C177.93724,47 171.764856,60.046796 167.176556,76.6221571 C159.674261,64.0383683 151.951891,55.0042941 145.242647,55.0042941 C135.566667,55.0042941 133.44292,73.794275 134.113536,94.9233262 C101.816994,107.93243 80,134.226231 80,172.067096 C80,227.877797 167.176556,254.924047 186,280 C204.964643,254.924047 292,227.877797 292,172.067096 C292,134.398349 270.381022,108.171862 238.326511,95.1016647 C239.014739,73.9001214 236.90632,55.0042941 227.203125,55.0042941 Z"
       id="path-2"
-    >
-    </path>
+    ></path>
     <filter
       x="-50%"
       y="-50%"
@@ -38,10 +37,9 @@
         stdDeviation="1.5"
         in="SourceAlpha"
         result="shadowBlurInner1"
-      >
-      </feGaussianBlur>
-      <feOffset dx="0" dy="0" in="shadowBlurInner1" result="shadowOffsetInner1">
-      </feOffset>
+      ></feGaussianBlur>
+      <feOffset dx="0" dy="0" in="shadowBlurInner1"
+        result="shadowOffsetInner1"></feOffset>
       <feComposite
         in="shadowOffsetInner1"
         in2="SourceAlpha"
@@ -49,14 +47,12 @@
         k2="-1"
         k3="1"
         result="shadowInnerInner1"
-      >
-      </feComposite>
+      ></feComposite>
       <feColorMatrix
         values="0 0 0 0 0.78651148   0 0 0 0 0.491210658   0 0 0 0 0.0677304808  0 0 0 1 0"
         type="matrix"
         in="shadowInnerInner1"
-      >
-      </feColorMatrix>
+      ></feColorMatrix>
     </filter>
   </defs>
   <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -66,15 +62,13 @@
           fill="url(#linearGradient-1)"
           fill-rule="evenodd"
           xlink:href="#path-2"
-        >
-        </use>
+        ></use>
         <use
           fill="black"
           fill-opacity="1"
           filter="url(#filter-3)"
           xlink:href="#path-2"
-        >
-        </use>
+        ></use>
       </g>
     </g>
   </g>


### PR DESCRIPTION
Fixes pre-existing `deno fmt --check` failure on `media/logo.svg` (unrelated formatting drift). This was blocking CI on unrelated dependency-update PRs.